### PR TITLE
Display an error message in the FE when the room is not found

### DIFF
--- a/frontend/src/pages/ConnectedPages/JoinRoom/index.tsx
+++ b/frontend/src/pages/ConnectedPages/JoinRoom/index.tsx
@@ -3,8 +3,8 @@ import { Redirect } from "react-router-dom";
 
 import "./joinRoom.css";
 import ConnectionManager from "../../../websockets/ConnectionManager";
-import {Method} from "axios";
-import {axiosRequest} from "../components/axiosRequest";
+import { Method } from "axios";
+import { axiosRequest } from "../components/axiosRequest";
 
 const JoinRoom: React.FC = () => {
   const [roomId, setRoomId] = useState<string | null>(null);
@@ -26,9 +26,9 @@ const JoinRoom: React.FC = () => {
       method: "GET" as Method,
       url: `/games/${roomId}`
     };
-    const game = (await axiosRequest(checkGameExists)).data;
+    const error = (await axiosRequest(checkGameExists)).error;
 
-    if (!game) {
+    if (error) {
       setGameNotFound(true);
       return;
     }

--- a/frontend/src/pages/ConnectedPages/JoinRoom/index.tsx
+++ b/frontend/src/pages/ConnectedPages/JoinRoom/index.tsx
@@ -3,10 +3,13 @@ import { Redirect } from "react-router-dom";
 
 import "./joinRoom.css";
 import ConnectionManager from "../../../websockets/ConnectionManager";
+import {Method} from "axios";
+import {axiosRequest} from "../components/axiosRequest";
 
 const JoinRoom: React.FC = () => {
   const [roomId, setRoomId] = useState<string | null>(null);
   const [isRedirected, setIsRedirected] = useState<boolean>(false);
+  const [gameNotFound, setGameNotFound] = useState<boolean>(false);
 
   const handleRoomIdChange = (
     event: React.ChangeEvent<HTMLInputElement>
@@ -14,10 +17,23 @@ const JoinRoom: React.FC = () => {
     setRoomId(event.target.value);
   };
 
-  const handleJoinGame = (): void => {
+  const handleJoinGame = async (): Promise<void> => {
     if (roomId === null) {
       return;
     }
+
+    const checkGameExists = {
+      method: "GET" as Method,
+      url: `/games/${roomId}`
+    };
+    const game = (await axiosRequest(checkGameExists)).data;
+
+    if (!game) {
+      setGameNotFound(true);
+      return;
+    }
+
+    setGameNotFound(false);
 
     const findRoomRequest = true;
 
@@ -42,6 +58,7 @@ const JoinRoom: React.FC = () => {
           onChange={handleRoomIdChange}
         />
       </div>
+      {gameNotFound && <div className="errorContainer">Game not found, please check you entered the correct value :)</div>}
       <button className="fullWidthButton" onClick={handleJoinGame}>
         Join game
       </button>

--- a/frontend/src/pages/ConnectedPages/JoinRoom/joinRoom.css
+++ b/frontend/src/pages/ConnectedPages/JoinRoom/joinRoom.css
@@ -1,3 +1,7 @@
 .fullWidthButton {
   width: 50%;
 }
+
+.errorContainer {
+  padding: 2%;
+}


### PR DESCRIPTION
Before, when trying to join a room that was not found, the app was crashing and leaving the user on a blank page. 
Now, this prevents redirection to an empty game page and displays an error message.