### PR TITLE
Record answers in db and display result in client

### DIFF
--- a/backend/src/controllers/game_controller.ts
+++ b/backend/src/controllers/game_controller.ts
@@ -83,6 +83,7 @@ export class GameController extends Controller {
     // set new game session
     game.tracks = tracks;
     game.currentTrackIndex = -1;
+    game.questionStartTimestamp = -1;
     req.gameSessions.new(game);
 
     // send game without tracks

--- a/backend/src/controllers/score_controller.spec.ts
+++ b/backend/src/controllers/score_controller.spec.ts
@@ -11,6 +11,7 @@ let score: Score;
 
 async function createUser(): Promise<User> {
   const user: User = new User();
+  user.id = "john";
   user.name = "John";
   await getRepository(User).save(user);
   return user;

--- a/backend/src/controllers/score_controller.ts
+++ b/backend/src/controllers/score_controller.ts
@@ -40,7 +40,7 @@ export class ScoreController extends Controller {
     score.game = new Game();
     score.game.id = parseInt(req.body.idGame, 10) || 0;
     score.user = new User();
-    score.user.id = parseInt(req.body.idUser, 10) || 0;
+    score.user.id = req.body.idUser || "";
     await getRepository(Score).save(score);
     res.sendJSON(score);
   }

--- a/backend/src/controllers/user_controller.spec.ts
+++ b/backend/src/controllers/user_controller.spec.ts
@@ -7,6 +7,7 @@ let user: User;
 
 async function createUser(): Promise<User> {
   const user: User = new User();
+  user.id = "john";
   user.name = "John";
   await getRepository(User).save(user);
   return user;
@@ -61,11 +62,13 @@ describe("Test GET, DELETE, GET user", () => {
 
 describe("Test POST, PUT, GET", () => {
   const user: User = new User();
+  user.id = "mickey";
   user.name = "Mickey";
   it("should create a new user", async () => {
     const res = await request(server)
       .post("/users")
       .send({
+        id: user.id,
         name: user.name,
       });
     expect(res.status).toEqual(200);

--- a/backend/src/controllers/user_controller.ts
+++ b/backend/src/controllers/user_controller.ts
@@ -16,7 +16,7 @@ export class UserController extends Controller {
 
   @get({ path: "/:id" })
   public async getUser(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const id: number = parseInt(req.params.id, 10) || 0;
+    const id: string = req.params.id;
     const user: User | undefined = await getRepository(User).findOne(id);
     if (user === undefined) {
       next();
@@ -28,6 +28,7 @@ export class UserController extends Controller {
   @post()
   public async addUser(req: Request, res: Response): Promise<void> {
     const user: User = new User();
+    user.id = req.body.id;
     user.name = req.body.name || null;
     await getRepository(User).save(user);
     res.sendJSON(user);
@@ -35,7 +36,7 @@ export class UserController extends Controller {
 
   @put({ path: "/:id" })
   public async editUser(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const id: number = parseInt(req.params.id, 10) || 0;
+    const id: string = req.params.id;
     const name: string = req.body.name || null;
     const user: User | undefined = await getRepository(User).findOne(id);
     if (user === undefined) {
@@ -51,7 +52,7 @@ export class UserController extends Controller {
 
   @del({ path: "/:id" })
   public async deleteTheme(req: Request, res: Response): Promise<void> {
-    const id: number = parseInt(req.params.id, 10) || 0;
+    const id: string = req.params.id;
     await getRepository(User).delete(id);
     res.status(204).send();
   }

--- a/backend/src/controllers/websockets_controller.ts
+++ b/backend/src/controllers/websockets_controller.ts
@@ -17,6 +17,7 @@ export enum OutboundMessageType {
   WAITING_ROOM_UPDATE = "WAITING_ROOM_UPDATE",
   QUESTION_UPDATE = "QUESTION_UPDATE",
   START_GAME = "START_GAME",
+  RECORDED_ANSWER = "RECORDED_ANSWER",
   ERROR = "ERROR",
 }
 
@@ -128,8 +129,10 @@ const SubmitAnswerHandler = (ws: WebSocket, req: RequestWithCache, { answer, gam
       score.game = game;
       score.user = new User();
       score.user.id = spotifyUser.id;
-      console.log(score);
+
       getRepository(Score).save(score);
+
+      ws.send(JSON.stringify({ type: OutboundMessageType.RECORDED_ANSWER, isCorrect: score.isCorrect }));
     })
     .catch(() => {
       console.error("Can't find Spotify user to add score");

--- a/backend/src/controllers/websockets_controller.ts
+++ b/backend/src/controllers/websockets_controller.ts
@@ -17,7 +17,7 @@ export enum OutboundMessageType {
   WAITING_ROOM_UPDATE = "WAITING_ROOM_UPDATE",
   QUESTION_UPDATE = "QUESTION_UPDATE",
   START_GAME = "START_GAME",
-  RECORDED_ANSWER = "RECORDED_ANSWER",
+  ANSWER_RESULT = "ANSWER_RESULT",
   ERROR = "ERROR",
 }
 
@@ -132,7 +132,7 @@ const SubmitAnswerHandler = (ws: WebSocket, req: RequestWithCache, { answer, gam
 
       getRepository(Score).save(score);
 
-      ws.send(JSON.stringify({ type: OutboundMessageType.RECORDED_ANSWER, isCorrect: score.isCorrect }));
+      ws.send(JSON.stringify({ type: OutboundMessageType.ANSWER_RESULT, isCorrect: score.isCorrect }));
     })
     .catch(() => {
       console.error("Can't find Spotify user to add score");

--- a/backend/src/controllers/websockets_controller.ts
+++ b/backend/src/controllers/websockets_controller.ts
@@ -95,22 +95,19 @@ const MessageHandlerFactory = (ws: WebSocket, req: RequestWithCache) => (msg: st
   try {
     const content = JSON.parse(msg);
 
-    if (content.type == InboundMessageType.PING) {
-      pingHandler(ws, req, content);
-      return;
+    switch (content.type) {
+      case InboundMessageType.PING:
+        pingHandler(ws, req, content);
+        break;
+      case InboundMessageType.JOIN_GAME:
+        joinGameHandler(ws, req, content);
+        break;
+      case InboundMessageType.REQUEST_START_GAME:
+        startGameHandler(ws, req, content);
+        break;
+      default:
+        ws.send(JSON.stringify({ type: OutboundMessageType.ERROR, message: "Invalid message type." }));
     }
-
-    if (content.type == InboundMessageType.JOIN_GAME) {
-      joinGameHandler(ws, req, content);
-      return;
-    }
-
-    if (content.type == InboundMessageType.REQUEST_START_GAME) {
-      startGameHandler(ws, req, content);
-      return;
-    }
-
-    ws.send(JSON.stringify({ type: OutboundMessageType.ERROR, message: "Invalid message type." }));
   } catch (e) {
     ws.send(JSON.stringify({ type: OutboundMessageType.ERROR, message: "Invalid message." }));
   }

--- a/backend/src/entities/game.ts
+++ b/backend/src/entities/game.ts
@@ -37,6 +37,7 @@ export class Game {
   currentTrackIndex: number;
   otherTracksIndexes: Array<number>;
   updateTimeout: Timeout;
+  questionStartTimestamp: number;
 
   roomManager: GameRoomManager;
 }

--- a/backend/src/entities/user.ts
+++ b/backend/src/entities/user.ts
@@ -1,9 +1,9 @@
-import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+import { Entity, PrimaryColumn, Column } from "typeorm";
 
 @Entity()
 export class User {
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryColumn()
+  id: string;
 
   @Column()
   name: string;

--- a/backend/src/gameSessions.ts
+++ b/backend/src/gameSessions.ts
@@ -70,6 +70,7 @@ export class GameSessions {
     logger.info(`Game ${game.title} playing ${game.tracks[game.currentTrackIndex].name} at index ${game.currentTrackIndex}. Preview url: ${game.tracks[game.currentTrackIndex].previewUrl}`);
     logger.info(`All guesses: ${JSON.stringify(answers)}`);
 
+    game.questionStartTimestamp = Date.now();
     game.roomManager.broadcastMessage({
       type: OutboundMessageType.QUESTION_UPDATE,
       previewUrl: game.tracks[game.currentTrackIndex].previewUrl,

--- a/backend/src/providers/spotify/user.ts
+++ b/backend/src/providers/spotify/user.ts
@@ -1,0 +1,27 @@
+import request from "request";
+import { logger } from "../../utils/logger";
+
+interface SpotifyUser {
+  display_name: string;
+  id: string;
+}
+
+export function getSpotifyUser(accessToken: string): Promise<SpotifyUser> {
+  const authOptions = {
+    headers: {
+      Authorization: `Authorization: Bearer ${accessToken}`,
+    },
+    json: true,
+  };
+
+  return new Promise<SpotifyUser>((resolve, reject) => {
+    request.get("https://api.spotify.com/v1/me", authOptions, (error, response, body) => {
+      if (!error && response.statusCode === 200) {
+        resolve(body);
+      } else {
+        logger.error(JSON.stringify(response));
+        reject();
+      }
+    });
+  });
+}

--- a/backend/src/providers/spotify/user.ts
+++ b/backend/src/providers/spotify/user.ts
@@ -1,7 +1,7 @@
 import request from "request";
 import { logger } from "../../utils/logger";
 
-interface SpotifyUser {
+export interface SpotifyUser {
   display_name: string;
   id: string;
 }

--- a/frontend/src/pages/ConnectedPages/Game/AnswerResult/index.tsx
+++ b/frontend/src/pages/ConnectedPages/Game/AnswerResult/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface IAnswerResult {
+  isCorrect: boolean;
+}
+
+const AnswerResult: React.FC<IAnswerResult> = ({
+  isCorrect
+}: IAnswerResult) => {
+  return (
+    <div className="flex-container column">
+      <div className="text-center">
+        <h2 className="fancy-text">Result:</h2>
+        <h1 className="fancy-text">
+          The answer was {isCorrect ? "correct =)" : "wrong =("}
+        </h1>
+        <div>Waiting for next question.</div>
+      </div>
+    </div>
+  );
+};
+
+export default AnswerResult;

--- a/frontend/src/pages/ConnectedPages/Game/Question/index.tsx
+++ b/frontend/src/pages/ConnectedPages/Game/Question/index.tsx
@@ -6,7 +6,7 @@ import { Answer } from "../../../../websockets/MessageType";
 interface IQuestion {
   previewUrl: string;
   answers: Answer[];
-  handleAnswer: (test: any) => void;
+  handleAnswer: (answer: Answer) => void;
 }
 
 const Question: React.FC<IQuestion> = ({
@@ -25,10 +25,10 @@ const Question: React.FC<IQuestion> = ({
       <div className="grid-container">
         <div>
           <div className="grid">
-            {answers.map((c, index) => (
-              <button key={index} onClick={() => handleAnswer(c.id)}>
-                <div>{`${c.name}`}</div>
-                <div>{`by ${c.artist}`}</div>
+            {answers.map((answer, index) => (
+              <button key={index} onClick={() => handleAnswer(answer)}>
+                <div>{`${answer.name}`}</div>
+                <div>{`by ${answer.artist}`}</div>
               </button>
             ))}
           </div>

--- a/frontend/src/pages/ConnectedPages/Game/index.tsx
+++ b/frontend/src/pages/ConnectedPages/Game/index.tsx
@@ -35,7 +35,8 @@ const Game: React.FC<RouteComponentProps> = ({ location }) => {
   const handleAnswer = (answer: Answer): void => {
     ConnectionManager.getInstance().sendMessage({
       type: MessageType.SUBMIT_ANSWER,
-      answer
+      answer,
+      gameId: querystring.parse(location.search).gameId as string
     });
   };
 

--- a/frontend/src/pages/ConnectedPages/Game/index.tsx
+++ b/frontend/src/pages/ConnectedPages/Game/index.tsx
@@ -11,6 +11,7 @@ import MessageType, {
 } from "../../../websockets/MessageType";
 import ConnectionManager from "../../../websockets/ConnectionManager";
 import Question from "./Question";
+import { getToken } from "../../../utils/cookies";
 
 const Game: React.FC<RouteComponentProps> = ({ location }) => {
   const [step, setStep] = useState<IGameEnum>(IGameEnum.COUNTDOWN);
@@ -36,7 +37,8 @@ const Game: React.FC<RouteComponentProps> = ({ location }) => {
     ConnectionManager.getInstance().sendMessage({
       type: MessageType.SUBMIT_ANSWER,
       answer,
-      gameId: querystring.parse(location.search).gameId as string
+      gameId: querystring.parse(location.search).gameId as string,
+      accessToken: getToken()
     });
   };
 

--- a/frontend/src/pages/ConnectedPages/Game/index.tsx
+++ b/frontend/src/pages/ConnectedPages/Game/index.tsx
@@ -8,17 +8,18 @@ import { RouteComponentProps, withRouter } from "react-router-dom";
 import MessageType, {
   QuestionUpdateMessage,
   Answer,
-  RecordedAnswerMessage
+  AnswerResultMessage
 } from "../../../websockets/MessageType";
 import ConnectionManager from "../../../websockets/ConnectionManager";
 import Question from "./Question";
 import { getToken } from "../../../utils/cookies";
+import AnswerResult from "./AnswerResult";
 
 const Game: React.FC<RouteComponentProps> = ({ location }) => {
   const [step, setStep] = useState<IGameEnum>(IGameEnum.COUNTDOWN);
   const [previewUrl, setPreviewUrl] = useState<string>("");
   const [answers, setAnswers] = useState<Answer[]>([]);
-  const [isCorrect, setIsCorrect] = useState<boolean>(false);
+  const [isAnswerCorrect, setIsAnswerCorrect] = useState<boolean>(false);
   const [score] = useState<number>(0);
 
   const onQuestionUpdateReceived = (question: QuestionUpdateMessage): void => {
@@ -28,8 +29,8 @@ const Game: React.FC<RouteComponentProps> = ({ location }) => {
     setStep(IGameEnum.QUIZZ);
   };
 
-  const onRecordedAnswerReceived = ({ isCorrect }: RecordedAnswerMessage) => {
-    setIsCorrect(isCorrect);
+  const onAnswerResultReceived = ({ isCorrect }: AnswerResultMessage) => {
+    setIsAnswerCorrect(isCorrect);
     setStep(IGameEnum.ANSWER_SUBMITTED);
   };
 
@@ -41,8 +42,8 @@ const Game: React.FC<RouteComponentProps> = ({ location }) => {
   );
 
   ConnectionManager.getInstance().registerCallbackForMessage(
-    MessageType.RECORDED_ANSWER,
-    onRecordedAnswerReceived
+    MessageType.ANSWER_RESULT,
+    onAnswerResultReceived
   );
 
   const handleAnswer = (answer: Answer): void => {
@@ -72,10 +73,7 @@ const Game: React.FC<RouteComponentProps> = ({ location }) => {
         </React.Fragment>
       )}
       {step === IGameEnum.ANSWER_SUBMITTED && (
-        <React.Fragment>
-          <div>The answer was {isCorrect ? "correct =)" : "wrong =("}</div>
-          <div>Waiting for next question.</div>
-        </React.Fragment>
+        <AnswerResult isCorrect={isAnswerCorrect} />
       )}
       {step === IGameEnum.SCORE && <Score score={score} />}
     </div>

--- a/frontend/src/pages/ConnectedPages/Game/index.tsx
+++ b/frontend/src/pages/ConnectedPages/Game/index.tsx
@@ -32,8 +32,11 @@ const Game: React.FC<RouteComponentProps> = ({ location }) => {
     onQuestionUpdateReceived
   );
 
-  const handleAnswer = (idTrack: string): void => {
-    console.log(idTrack);
+  const handleAnswer = (answer: Answer): void => {
+    ConnectionManager.getInstance().sendMessage({
+      type: MessageType.SUBMIT_ANSWER,
+      answer
+    });
   };
 
   return (

--- a/frontend/src/pages/ConnectedPages/Game/types.tsx
+++ b/frontend/src/pages/ConnectedPages/Game/types.tsx
@@ -1,5 +1,6 @@
 export enum IGameEnum {
   "COUNTDOWN",
   "QUIZZ",
+  "ANSWER_SUBMITTED",
   "SCORE"
 }

--- a/frontend/src/websockets/MessageType.ts
+++ b/frontend/src/websockets/MessageType.ts
@@ -29,6 +29,7 @@ export interface SubmitAnswerMessage {
   type: MessageType.SUBMIT_ANSWER;
   answer: Answer;
   gameId: string;
+  accessToken: string;
 }
 
 export interface GameStartMessage {

--- a/frontend/src/websockets/MessageType.ts
+++ b/frontend/src/websockets/MessageType.ts
@@ -6,7 +6,7 @@ enum MessageType {
   START_GAME = "START_GAME",
   REQUEST_START_GAME = "REQUEST_START_GAME",
   SUBMIT_ANSWER = "SUBMIT_ANSWER",
-  RECORDED_ANSWER = "RECORDED_ANSWER"
+  ANSWER_RESULT = "ANSWER_RESULT"
 }
 
 export interface Answer {
@@ -33,8 +33,8 @@ export interface SubmitAnswerMessage {
   accessToken: string;
 }
 
-export interface RecordedAnswerMessage {
-  type: MessageType.RECORDED_ANSWER;
+export interface AnswerResultMessage {
+  type: MessageType.ANSWER_RESULT;
   isCorrect: boolean;
 }
 

--- a/frontend/src/websockets/MessageType.ts
+++ b/frontend/src/websockets/MessageType.ts
@@ -4,8 +4,10 @@ enum MessageType {
   QUESTION_UPDATE = "QUESTION_UPDATE",
   WAITING_ROOM_UPDATE = "WAITING_ROOM_UPDATE",
   START_GAME = "START_GAME",
-  REQUEST_START_GAME = "REQUEST_START_GAME"
+  REQUEST_START_GAME = "REQUEST_START_GAME",
+  SUBMIT_ANSWER = "SUBMIT_ANSWER"
 }
+
 export interface Answer {
   id: string;
   name: string;
@@ -21,6 +23,11 @@ export interface QuestionUpdateMessage {
   type: MessageType.QUESTION_UPDATE;
   previewUrl: string;
   answers: Answer[];
+}
+
+export interface SubmitAnswerMessage {
+  type: MessageType.SUBMIT_ANSWER;
+  answer: Answer;
 }
 
 export interface GameStartMessage {

--- a/frontend/src/websockets/MessageType.ts
+++ b/frontend/src/websockets/MessageType.ts
@@ -28,6 +28,7 @@ export interface QuestionUpdateMessage {
 export interface SubmitAnswerMessage {
   type: MessageType.SUBMIT_ANSWER;
   answer: Answer;
+  gameId: string;
 }
 
 export interface GameStartMessage {

--- a/frontend/src/websockets/MessageType.ts
+++ b/frontend/src/websockets/MessageType.ts
@@ -5,7 +5,8 @@ enum MessageType {
   WAITING_ROOM_UPDATE = "WAITING_ROOM_UPDATE",
   START_GAME = "START_GAME",
   REQUEST_START_GAME = "REQUEST_START_GAME",
-  SUBMIT_ANSWER = "SUBMIT_ANSWER"
+  SUBMIT_ANSWER = "SUBMIT_ANSWER",
+  RECORDED_ANSWER = "RECORDED_ANSWER"
 }
 
 export interface Answer {
@@ -30,6 +31,11 @@ export interface SubmitAnswerMessage {
   answer: Answer;
   gameId: string;
   accessToken: string;
+}
+
+export interface RecordedAnswerMessage {
+  type: MessageType.RECORDED_ANSWER;
+  isCorrect: boolean;
 }
 
 export interface GameStartMessage {


### PR DESCRIPTION
This PR enables saving score in database and displaying answer result in the frontend.
To do so, I also had to refactor the `User` table to store directly Spotify ids, so we can easily identify a user thanks to its `access_token`.
