### PR TITLE
⬆️ Bump node version on prod frontend

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,5 +1,5 @@
 #### Stage 1: Build the react application
-FROM node:8.12.0-alpine as build
+FROM node:12.13-alpine as build
 
 WORKDIR /app
 


### PR DESCRIPTION
Deployment fails because the app doesn't build with the current node version.

For later : we should build the frontend as part of the CI tests.